### PR TITLE
add hint on how to share files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     privileged: true
     volumes:
     - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    # use /share inside container to share files with /host/directory on host
+    # - /host/directory:/share
     environment:
       LC_ALL: "en_US.UTF-8"
       LANG: "en_US.UTF-8"


### PR DESCRIPTION
may not be obvious to novice users, but will most likely be needed (+ if people realize it only after creating the container, it's too late).