### PR TITLE
🔧 Build: Skip RabbitMQ install in CI

### DIFF
--- a/playbook-build.yml
+++ b/playbook-build.yml
@@ -132,7 +132,7 @@
   # TODO control version
   # could install with conda, but how to set up the systemd service?
   - name: Install RabbitMQ server service
-    tags: [rabbitmq]
+    tags: [rabbitmq, ci_skip]
     become: true
     become_user: "{{ root_user }}"
     ansible.builtin.import_tasks: local/tasks/rabbitmq.yml


### PR DESCRIPTION
The CI in #243 fails because a RabbitMQ issue, unrelated to the changes in that PR.

Logs show "Setting up rabbitmq-server (3.12.1-1ubuntu1.4)". This revision was uploaded a little over a week ago, after our last successful CI run:

https://launchpad.net/ubuntu/+source/rabbitmq-server/3.12.1-1ubuntu1.4