### PR TITLE
✨ Build: Split `playbook-build.yml` into base + full layers

### DIFF
--- a/local/tasks/customise-gui.yml
+++ b/local/tasks/customise-gui.yml
@@ -37,21 +37,3 @@
     path: "${HOME}/Desktop"
     state: directory
     mode: "0755"
-
-- name: Symlink readme to Desktop
-  become: true
-  become_user: "{{ vm_user }}"
-  ansible.builtin.file:
-    src: "{{ readme_vm_path }}"
-    dest: "${HOME}/Desktop/{{ readme_vm_path | basename }}"
-    state: link
-    force: true
-
-- name: Symlink release notes to Desktop
-  become: true
-  become_user: "{{ vm_user }}"
-  ansible.builtin.file:
-    src: "{{ release_notes_vm_path }}"
-    dest: "${HOME}/Desktop/{{ release_notes_vm_path | basename }}"
-    state: link
-    force: true

--- a/local/tasks/dev.yml
+++ b/local/tasks/dev.yml
@@ -1,0 +1,13 @@
+---
+- name: Install development packages with apt
+  become: true
+  ansible.builtin.apt:
+    name:
+    - gfortran
+    - libblas-dev
+    - liblapack-dev
+    - libfftw3-dev
+    - libfftw3-doc
+    - openmpi-bin
+    - libopenmpi-dev
+    - cmake

--- a/playbook-build-dev.yml
+++ b/playbook-build-dev.yml
@@ -1,0 +1,163 @@
+---
+- name: Prepare for VM build
+  hosts: "{{ build_hosts | default('vagrant') }}"
+
+  vars:
+    vm_name_suffix: "{{ '-dev' if build_variant | default('full') == 'dev' else '' }}"
+
+  pre_tasks:
+  - name: Test configuration
+    tags: [init]
+    ansible.builtin.debug:
+      msg: "RUNNING PLAYBOOK FOR '{{ vm_name }}{{ vm_name_suffix }}' VERSION '{{ vm_version }}' (variant: {{ build_variant | default('full') }})"
+
+  - name: Testing ansible environment
+    tags: [init]
+    ansible.builtin.debug:
+      msg: Connecting to host '{{ inventory_hostname }}' as user '{{ ansible_user }}'
+
+  # Install headers for guest-additions. Use kernel-specific package because
+  # linux-headers-generic can be broken on ARM64 (depends on non-existent version).
+  - name: Install linux-headers for guest-additions
+    tags: [init]
+    when: "inventory_hostname.startswith('vagrant')"
+    become: true
+    ansible.builtin.apt:
+      update_cache: true
+      cache_valid_time: 86400
+      name: "linux-headers-{{ ansible_facts['kernel'] }}"
+
+  - name: Make local dist folder
+    tags: [init]
+    ansible.builtin.file:
+      state: directory
+      path: "{{ local_dist_folder }}/"
+      mode: "0755"
+    delegate_to: localhost
+    when: release_notes_locally is defined and release_notes_locally
+
+- name: Build VM (base layer)
+  hosts: "{{ build_hosts | default('vagrant') }}"
+
+  vars:
+    vm_name_suffix: "{{ '-dev' if build_variant | default('full') == 'dev' else '' }}"
+
+  tasks:
+  # Generic Tasks
+  # These tasks are run for any VM build, regardless of the software installed
+  # They setup the VM user, commandline interface, and (optionally) desktop GUI
+
+  - name: Update system package managers (apt, pip)
+    tags: [init]
+    ansible.builtin.include_tasks: local/tasks/ensure-apt-pip.yml
+
+  - name: "Add QM user '{{ vm_user }}'"
+    tags: [add_user]
+    ansible.builtin.import_tasks: local/tasks/add-qm-user.yml
+
+  - name: "Add release notes section for the operating system"
+    tags: [release_notes]
+    ansible.builtin.import_tasks: local/tasks/release-notes-system.yml
+
+  - name: Customise bash terminal for QM
+    tags: [customise-bash]
+    become: true
+    become_user: "{{ vm_user }}"
+    ansible.builtin.import_tasks: local/tasks/customise-bash.yml
+
+  - name: Install common text editors
+    tags: [editors]
+    ansible.builtin.import_tasks: local/tasks/editors.yml
+
+  - name: Install dev packages
+    tags: [dev]
+    ansible.builtin.import_tasks: local/tasks/dev.yml
+
+  - name: Add desktop GUI
+    tags: [ubuntu_desktop, ci_skip]
+    when: not vm_headless
+    become: true
+    block:
+    # Installing ubuntu-desktop pulls in NetworkManager, which can cause the network
+    # interface to lose its IP mid-install. We set networkd as the renderer.
+    - name: Set netplan renderer to networkd
+      ansible.builtin.copy:
+        dest: /etc/netplan/99-stay-with-networkd.yaml
+        content: |
+          network:
+            version: 2
+            renderer: networkd
+        mode: "0600"
+
+    - name: Install Ubuntu desktop
+      ansible.builtin.import_role:
+        name: marvel-nccr.ubuntu_desktop
+      vars:
+        ubuntu_desktop_vm_user: "{{ vm_user }}"
+        ubuntu_desktop_browser: "{{ vm_browser }}"
+        ubuntu_desktop_wm_package: "{{ vm_wm_package }}"
+
+  - name: Customise GUI for QM
+    tags: [customise-gui, ci_skip]
+    when: not vm_headless
+    become: true
+    become_user: "{{ vm_user }}"
+    ansible.builtin.import_tasks: local/tasks/customise-gui.yml
+
+  - name: Setup QM to run simulations
+    tags: [simsetup]
+    ansible.builtin.import_tasks: local/tasks/simulation-setup.yml
+
+  - name: Install plotting tools (via apt)
+    # TODO we may want to eventually install these with conda
+    # (jmol and gnuplot are already installed via conda-forge)
+    tags: [plotting]
+    ansible.builtin.import_tasks: local/tasks/plotting-tools.yml
+    vars:
+      packages: [grace, xcrysden, default-jre]
+
+  - name: Install SLURM service
+    tags: [slurm, ci_skip]
+    ansible.builtin.import_role:
+      name: marvel-nccr.slurm
+
+  - name: Install conda+mamba
+    tags: [conda]
+    ansible.builtin.import_role:
+      name: chrisjsewell.conda.user_install
+    become: true
+    become_user: "{{ vm_user }}"
+    vars:
+      miniforge_version: "25.11.0-1"
+      miniforge_checksums:
+        x86_64: "sha256:be1bad9d4e67a8753eb76fb4940e9a08036786675c7adf060627e55791bf110d"
+        aarch64: "sha256:43a3783f9e121088f1c92b131b4305b9ebf159424ad2543dfcfc0f1952b5e127"
+      conda_folder: "~/.conda"
+      conda_installer_url: "https://github.com/conda-forge/miniforge/releases/download/{{ miniforge_version }}/Miniforge3-{{ miniforge_version }}-Linux-{{ ansible_facts['architecture'] }}.sh"
+      conda_installer_checksum: "{{ miniforge_checksums[ansible_facts['architecture']] }}"
+      conda_activate_alias: workon
+      conda_executable: conda
+
+  - name: Install visualise conda environment
+    tags: [visualise-env, code-envs]
+    ansible.builtin.include_tasks:
+      file: local/tasks/conda-env-install.yml
+      apply:
+        tags: [visualise-env, code-envs]
+    vars:
+      conda_env: visualise
+      packages: [jmol, gnuplot]
+      bin_patterns: [jmol, gnuplot]
+
+  post_tasks:
+  # These break idempotency,
+  # so only run once all other tasks have completed
+
+  - name: "Clean caches"
+    tags: [never, cleanup]
+    ansible.builtin.import_tasks: local/tasks/clean-caches.yml
+  - name: "Remove content from: {{ build_dir }}"
+    tags: [never, cleanup]
+    become: true
+    ansible.builtin.command: rm -rf {{ build_dir }}/*
+    changed_when: true

--- a/playbook-build.yml
+++ b/playbook-build.yml
@@ -1,101 +1,14 @@
 ---
-- name: Prepare for VM build
+- name: Build base Quantum Mobile layer
+  ansible.builtin.import_playbook: playbook-build-dev.yml
+
+- name: Build VM (full layer)
   hosts: "{{ build_hosts | default('vagrant') }}"
 
-  pre_tasks:
-  - name: Test configuration
-    tags: [init]
-    ansible.builtin.debug:
-      msg: RUNNING PLAYBOOK FOR '{{ vm_name }}' VERSION '{{ vm_version }}'
-
-  - name: Testing ansible environment
-    tags: [init]
-    ansible.builtin.debug:
-      msg: Connecting to host '{{ inventory_hostname }}' as user '{{ ansible_user }}'
-
-  # Install headers for guest-additions. Use kernel-specific package because
-  # linux-headers-generic can be broken on ARM64 (depends on non-existent version).
-  - name: Install linux-headers for guest-additions
-    tags: [init]
-    when: "inventory_hostname.startswith('vagrant')"
-    become: true
-    ansible.builtin.apt:
-      update_cache: true
-      cache_valid_time: 86400
-      name: "linux-headers-{{ ansible_facts['kernel'] }}"
-
-  - name: Make local dist folder
-    tags: [init]
-    ansible.builtin.file:
-      state: directory
-      path: "{{ local_dist_folder }}/"
-      mode: "0755"
-    delegate_to: localhost
-    when: release_notes_locally is defined and release_notes_locally
-
-- name: Build VM
-  hosts: "{{ build_hosts | default('vagrant') }}"
+  vars:
+    vm_name_suffix: ""
 
   tasks:
-  # Generic Tasks
-  # These tasks are run for any VM build, regardless of the software installed
-  # They setup the VM user, commandline interface, and (optionally) desktop GUI
-
-  - name: Update system package managers (apt, pip)
-    tags: [init]
-    ansible.builtin.include_tasks: local/tasks/ensure-apt-pip.yml
-
-  - name: "Add QM user '{{ vm_user }}'"
-    tags: [add_user]
-    ansible.builtin.import_tasks: local/tasks/add-qm-user.yml
-
-  - name: "Add release notes section for the operating system"
-    tags: [release_notes]
-    ansible.builtin.import_tasks: local/tasks/release-notes-system.yml
-
-  - name: Customise bash terminal for QM
-    tags: [customise-bash]
-    become: true
-    become_user: "{{ vm_user }}"
-    ansible.builtin.import_tasks: local/tasks/customise-bash.yml
-
-  - name: Install common text editors
-    tags: [editors]
-    ansible.builtin.import_tasks: local/tasks/editors.yml
-
-  - name: Add desktop GUI
-    tags: [ubuntu_desktop, ci_skip]
-    when: not vm_headless
-    become: true
-    block:
-    # Installing ubuntu-desktop pulls in NetworkManager, which can cause the network
-    # interface to lose its IP mid-install. We set networkd as the renderer.
-    - name: Set netplan renderer to networkd
-      ansible.builtin.copy:
-        dest: /etc/netplan/99-stay-with-networkd.yaml
-        content: |
-          network:
-            version: 2
-            renderer: networkd
-        mode: "0600"
-
-    - name: Install Ubuntu desktop
-      ansible.builtin.import_role:
-        name: marvel-nccr.ubuntu_desktop
-      vars:
-        ubuntu_desktop_vm_user: "{{ vm_user }}"
-        ubuntu_desktop_browser: "{{ vm_browser }}"
-        ubuntu_desktop_wm_package: "{{ vm_wm_package }}"
-
-  - name: Customise GUI for QM
-    tags: [customise-gui, ci_skip]
-    when: not vm_headless
-    become: true
-    become_user: "{{ vm_user }}"
-    ansible.builtin.import_tasks: local/tasks/customise-gui.yml
-  - name: Setup QM to run simulations
-    tags: [simsetup]
-    ansible.builtin.import_tasks: local/tasks/simulation-setup.yml
   - name: "Add user README"
     tags: [add_readme]
     become: true
@@ -116,49 +29,21 @@
         Wannier90: http://www.wannier.org
         Yambo: http://www.yambo-code.org/
 
-  - name: Install plotting tools (via apt)
-    # TODO we may want to eventually install these with conda
-    # (jmol and gnuplot are already installed via conda-forge)
-    tags: [plotting]
-    ansible.builtin.import_tasks: local/tasks/plotting-tools.yml
-    vars:
-      packages: [grace, xcrysden, default-jre]
-
-  - name: Install SLURM service
-    tags: [slurm, ci_skip]
-    ansible.builtin.import_role:
-      name: marvel-nccr.slurm
-
-  # TODO control version
-  # could install with conda, but how to set up the systemd service?
-  - name: Install RabbitMQ server service
-    tags: [rabbitmq, ci_skip]
-    become: true
-    become_user: "{{ root_user }}"
-    ansible.builtin.import_tasks: local/tasks/rabbitmq.yml
-
-  - name: Install PostrgeSQL server service
-    tags: [postgresql]
-    become: true
-    become_user: "{{ root_user }}"
-    ansible.builtin.import_tasks: local/tasks/postgresql.yml
-
-  - name: Install conda+mamba
-    tags: [conda]
-    ansible.builtin.import_role:
-      name: chrisjsewell.conda.user_install
+  - name: Symlink README and release notes to Desktop
+    tags: [add_readme, customise-gui, ci_skip]
+    when: not vm_headless
     become: true
     become_user: "{{ vm_user }}"
-    vars:
-      miniforge_version: "25.11.0-1"
-      miniforge_checksums:
-        x86_64: "sha256:be1bad9d4e67a8753eb76fb4940e9a08036786675c7adf060627e55791bf110d"
-        aarch64: "sha256:43a3783f9e121088f1c92b131b4305b9ebf159424ad2543dfcfc0f1952b5e127"
-      conda_folder: "~/.conda"
-      conda_installer_url: "https://github.com/conda-forge/miniforge/releases/download/{{ miniforge_version }}/Miniforge3-{{ miniforge_version }}-Linux-{{ ansible_facts['architecture'] }}.sh"
-      conda_installer_checksum: "{{ miniforge_checksums[ansible_facts['architecture']] }}"
-      conda_activate_alias: workon
-      conda_executable: conda
+    ansible.builtin.file:
+      src: "{{ item }}"
+      dest: "${HOME}/Desktop/{{ item | basename }}"
+      state: link
+      force: true
+    loop:
+    - "{{ readme_vm_path }}"
+    - "{{ release_notes_vm_path }}"
+    loop_control:
+      label: "{{ item | basename }}"
 
   - name: Install code environment
     tags: [code-envs]
@@ -224,9 +109,6 @@
       - macroave
       - stm
       - optical
-    - name: visualise
-      pkgs: [jmol, gnuplot]
-      bin_patterns: [jmol, gnuplot]
     - name: wannier90
       pkgs: [wannier90=3.1.0]
       bin_patterns: ["wannier90.*", "w90*", "postw90.*"]
@@ -236,6 +118,20 @@
     when: item.arch is not defined or ansible_facts['architecture'] in item.arch
     loop_control:
       label: "{{ item.name }}"
+
+  # TODO control version
+  # could install with conda, but how to set up the systemd service?
+  - name: Install RabbitMQ server service
+    tags: [rabbitmq, ci_skip]
+    become: true
+    become_user: "{{ root_user }}"
+    ansible.builtin.import_tasks: local/tasks/rabbitmq.yml
+
+  - name: Install PostrgeSQL server service
+    tags: [postgresql]
+    become: true
+    become_user: "{{ root_user }}"
+    ansible.builtin.import_tasks: local/tasks/postgresql.yml
 
   - name: Build AiiDA package list with architecture-specific plugins
     tags: [aiida-env]
@@ -400,16 +296,3 @@
     vars:
       aiida_examples_folder: "~/Desktop/aiida-examples"
       aiida_verdi_cmd: "~/.conda/bin/conda run -n {{ aiida_conda_env }} verdi"
-
-  post_tasks:
-  # These break idempotency,
-  # so only run once all other tasks have completed
-
-  - name: "Clean caches"
-    tags: [never, cleanup]
-    ansible.builtin.import_tasks: local/tasks/clean-caches.yml
-  - name: "Remove content from: {{ build_dir }}"
-    tags: [never, cleanup]
-    become: true
-    ansible.builtin.command: rm -rf {{ build_dir }}/*
-    changed_when: true

--- a/playbook-package.yml
+++ b/playbook-package.yml
@@ -7,6 +7,7 @@
   vars:
     tmp_vdisk_vdi: "tmp.vdi"
     tmp_vdisk_vmdk: "tmp.vmdk"
+    vm_name_suffix: "{{ '-dev' if build_variant | default('full') == 'dev' else '' }}"
 
   tasks:
   - name: Set VM ID
@@ -129,7 +130,7 @@
 
   - name: Set output path for image
     ansible.builtin.set_fact:
-      image_path: "{{ local_dist_folder }}/quantum_mobile_{{ vm_version }}_{{ 'x86_64' if ansible_facts['architecture'] == 'x86_64' else 'arm64' }}.ova"
+      image_path: "{{ local_dist_folder }}/quantum_mobile{{ vm_name_suffix }}_{{ vm_version }}_{{ 'x86_64' if ansible_facts['architecture'] == 'x86_64' else 'arm64' }}.ova"
     tags: [export, release]
 
   - name: Remove old image file
@@ -143,7 +144,7 @@
       vboxmanage export "{{ vm_id }}"  \
         -o {{ image_path }} \
         --vsys 0 \
-        --product "{{ vm_name }}" \
+        --product "{{ vm_name }}{{ vm_name_suffix }}" \
         --version "{{ vm_version }}" \
         --producturl "{{ vm_url }}" \
         --vendor "{{ vm_author }}" \

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ allowlist_externals = vagrant
 commands = vagrant {posargs:up}
 
 [testenv:ansible]
-description = Run ansible on an existing VM
+description = Run ansible on an existing VM (full Quantum Mobile)
 deps = -rrequirements.txt
 passenv =
     HOME
@@ -34,6 +34,14 @@ commands = ansible-playbook {env:BUILD_PLAYBOOK:playbook-build.yml} {posargs}
 # tox -e ansible -- --extra-vars "build_hosts=aws"
 # to clean build files:
 # tox -e ansible -- --tags cleanup
+
+[testenv:ansible-dev]
+description = Run ansible on an existing VM (bare-metal "dev" variant)
+deps = {[testenv:ansible]deps}
+passenv = {[testenv:ansible]passenv}
+allowlist_externals = {[testenv:ansible]allowlist_externals}
+commands_pre = {[testenv:ansible]commands_pre}
+commands = ansible-playbook playbook-build-dev.yml --extra-vars build_variant=dev {posargs}
 
 
 [testenv:update-ansible]
@@ -54,7 +62,7 @@ commands =
 
 
 [testenv:package]
-description = Package a built Vagrant box for distribution
+description = Package a built Vagrant box for distribution (full Quantum Mobile)
 deps = -rrequirements.txt
 passenv =
     HOME
@@ -63,6 +71,12 @@ passenv =
     DOCKER_TLS_VERIFY
 commands =
     ansible-playbook playbook-package.yml {posargs}
+
+[testenv:package-dev]
+description = Package a built Vagrant box for distribution ("dev" variant)
+deps = {[testenv:package]deps}
+passenv = {[testenv:package]passenv}
+commands = ansible-playbook playbook-package.yml --extra-vars build_variant=dev {posargs}
 
 
 [testenv:docs-{update,clean}]


### PR DESCRIPTION
Introduce a `playbook-build-dev.yml` playbook that provisions a bare-metal Quantum Mobile image — user, desktop, dev build toolchain, SLURM, conda, and the `visualise` conda env — but no simulation codes and no AiiDA. The variant is aimed at organisers of schools who want a neutral starting point they can customise for their event rather than stripping features out of the full release.

`playbook-build.yml` is refactored to `import_playbook` the dev playbook and then run only the full-only plays: RabbitMQ, PostgreSQL, code environments, AiiDA environment and profile, AiiDA Jupyter service, AiiDA computers and codes, pseudopotentials, AiiDA examples, and the user README. RabbitMQ and PostgreSQL live in the full layer because the AiiDA daemon is their only consumer on the VM, so shipping them in the bare-metal image would install services with nothing to drive them. A `build_variant` variable (default `full`) drives a `vm_name_suffix` consumed by `playbook-package.yml` so the dev build exports as `quantum_mobile-dev_<version>_<arch>.ova` next to the full `quantum_mobile_<version>_<arch>.ova`, with the matching `--product` option in the OVA metadata.

The README and release-notes desktop symlinks move out of `customise-gui.yml` into a dedicated loop in the full playbook, since the dev image ships without those files and the base GUI customisation should not depend on them. The new `local/tasks/dev.yml` installs the Fortran/MPI build toolchain (`gfortran`, BLAS/LAPACK, FFTW, OpenMPI, `cmake`) under the `dev` tag so developers can compile codes from source without pulling in the full conda-forge code set.