### PR TITLE
🐛 Plotting: Restore gnuplot via apt and force Qt xcb platform

### DIFF
--- a/local/tasks/plotting-tools.yml
+++ b/local/tasks/plotting-tools.yml
@@ -11,6 +11,16 @@
     name: "{{ packages | join(' ') }}"
   register: plot_versions
 
+- name: "Force Qt applications to use the xcb platform plugin"
+  when: "'gnuplot' in packages"
+  become: true
+  become_user: "{{ root_user }}"
+  ansible.builtin.blockinfile:
+    path: "/home/{{ vm_user }}/.bashrc"
+    marker: '## {mark} ANSIBLE MANAGED BLOCK (QT)'
+    block: |
+      export QT_QPA_PLATFORM=xcb
+
 - name: "Configure XCrySDen for virtual machine compatibility"
   # XCrySDen requests an OpenGL accumulation buffer by default, which is not
   # supported by virtual GPUs (SVGA3D, llvmpipe). Disabling it allows the togl

--- a/playbook-build-dev.yml
+++ b/playbook-build-dev.yml
@@ -109,12 +109,13 @@
     ansible.builtin.import_tasks: local/tasks/simulation-setup.yml
 
   - name: Install plotting tools (via apt)
-    # TODO we may want to eventually install these with conda
-    # (jmol and gnuplot are already installed via conda-forge)
+    # gnuplot is installed here rather than via conda-forge because the
+    # conda build ships a qt driver that fails to launch inside the VM
+    # (see https://github.com/marvel-nccr/quantum-mobile/issues/247).
     tags: [plotting]
     ansible.builtin.import_tasks: local/tasks/plotting-tools.yml
     vars:
-      packages: [grace, xcrysden, default-jre]
+      packages: [grace, xcrysden, default-jre, gnuplot]
 
   - name: Install SLURM service
     tags: [slurm, ci_skip]
@@ -146,8 +147,8 @@
         tags: [visualise-env, code-envs]
     vars:
       conda_env: visualise
-      packages: [jmol, gnuplot]
-      bin_patterns: [jmol, gnuplot]
+      packages: [jmol]
+      bin_patterns: [jmol]
 
   post_tasks:
   # These break idempotency,


### PR DESCRIPTION
Fixes #247 

Gnuplot was broken: two unrelated failures stacked on top of each other:

- the conda-forge `gnuplot` 5.4 in the `visualise` env could not locate its own `gnuplot_qt` driver and asked for `GNUPLOT_DRIVER_DIR`.

- the apt `gnuplot` 6.0 available on Ubuntu 24.04 cannot open its qt terminal under VirtualBox either — it fails with EGL / Mesa / Zink errors, apparently because no usable GL context can be created for the virtual GPU.

Install `gnuplot` via apt instead of conda and drop it from the `visualise` conda env, which sidesteps the driver-lookup failure. Then write `QT_QPA_PLATFORM=xcb` to `/etc/environment` via `plotting-tools.yml` so Qt applications use the X11 platform plugin, which — experimentally — restores gnuplot's qt terminal under VirtualBox.