### PR TITLE
✨ Desktop: Add Firefox shortcut to Desktop

### DIFF
--- a/local/tasks/customise-gui.yml
+++ b/local/tasks/customise-gui.yml
@@ -50,6 +50,20 @@
     state: directory
     mode: "0755"
 
+- name: Copy Firefox .desktop to Desktop
+  ansible.builtin.copy:
+    src: /var/lib/snapd/desktop/applications/firefox_firefox.desktop
+    dest: "/home/{{ vm_user }}/Desktop/firefox_firefox.desktop"
+    remote_src: true
+    owner: "{{ vm_user }}"
+    group: "{{ vm_user }}"
+    mode: "0755"
+
+- name: Mark Firefox shortcut as trusted
+  ansible.builtin.command:
+    cmd: dbus-run-session -- gio set /home/{{ vm_user }}/Desktop/firefox_firefox.desktop metadata::trusted true
+  changed_when: true
+
 - name: Remove update-notifier
   become: true
   become_user: "{{ root_user }}"


### PR DESCRIPTION
Users wanted a clickable browser on the desktop rather than having to open GNOME Activities and type "firefox" to launch one.

Copy the Firefox `.desktop` file into `~/Desktop/` with mode `0755`. On Ubuntu 24.04 Firefox ships only as a snap, so the system file lives at `/var/lib/snapd/desktop/applications/firefox_firefox.desktop` rather than the usual `/usr/share/applications/` location, and the destination on the user's desktop keeps that same name.

A `.desktop` file with `+x` alone is not enough — GNOME's `ding` desktop-icons extension on 24.04 also requires a `metadata::trusted` GVFS xattr before it will launch the shortcut; without it the user sees an "Invalid Permissions on Desktop File" popup. Setting that xattr via `gio set metadata::trusted true` normally needs a DBus session bus, which does not exist during Ansible provisioning. Wrap the call in `dbus-run-session` so a throw-away bus is spawned just long enough for the write to reach GVFS's on-disk metadata under `~/.local/share/gvfs-metadata/`, which the user's GNOME session then picks up on first login.

A symlink from `~/Desktop/` to the system file was the first attempt and is cleaner, but `ding` still refuses to launch symlinked shortcuts without the trust xattr, so the task copies the file instead.