### PR TITLE
🔄 Package: Move `update-notifier` removal into the packaging playbook

### DIFF
--- a/local/tasks/customise-gui.yml
+++ b/local/tasks/customise-gui.yml
@@ -63,11 +63,3 @@
   ansible.builtin.command:
     cmd: dbus-run-session -- gio set /home/{{ vm_user }}/Desktop/firefox_firefox.desktop metadata::trusted true
   changed_when: true
-
-- name: Remove update-notifier
-  become: true
-  become_user: "{{ root_user }}"
-  ansible.builtin.apt:
-    name: update-notifier
-    state: absent
-    purge: true

--- a/playbook-package.yml
+++ b/playbook-package.yml
@@ -47,6 +47,10 @@
     ansible.builtin.shell: vagrant ssh-config > vagrant-ssh
     tags: [clean]
 
+  - name: Remove update-notifier
+    ansible.builtin.command: ssh -F vagrant-ssh default "sudo apt-get purge -y update-notifier"
+    tags: [clean]
+
   - name: Clear bash history
     ansible.builtin.shell: ssh -F vagrant-ssh default "cat /dev/null > ~/.bash_history && history -c"
     tags: [clean]


### PR DESCRIPTION
Removing the `update-notifier` package during GUI customisation had the side-effect of invalidating apt state in a way that could surface later in the same provisioning run — the `ensure-apt-pip` refresh honoured `cache_valid_time: 86400` and skipped re-updating, so subsequent tasks occasionally failed to find standard packages like `ubuntu-desktop-minimal`, which would break provisioning even if they had already been installed.

Move the purge out of `local/tasks/customise-gui.yml` and into `playbook-package.yml`, where it now runs right after the VM reload and before the disk cleanup. This keeps the Software Updater popup off the shipped image (the only place it actually matters — dev VMs re-provisioned locally can still show it, which is not an issue) without touching apt state mid-build.