### PR TITLE
🐛 Koopmans: do not use editable install

### DIFF
--- a/qe-school/tasks/koopmans.yml
+++ b/qe-school/tasks/koopmans.yml
@@ -71,6 +71,6 @@
 
 - name: Install koopmans package
   ansible.builtin.command:
-    cmd: ~/.conda/envs/koopmans/bin/pip install -e .
+    cmd: ~/.conda/envs/koopmans/bin/pip install .
     chdir: "/home/{{ vm_user }}/tmp/koopmans"
     creates: "/home/{{ vm_user }}/.conda/envs/koopmans/bin/koopmans"


### PR DESCRIPTION
The editable install means the directory will be the src for pip; but the directory is removed during the packaging step. Here we do not use an editable install for the installation of koopmans.