### PR TITLE
✨ Basic packages: Add `tree` and rename task from "editors"

### DIFF
--- a/local/tasks/basic-packages.yml
+++ b/local/tasks/basic-packages.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install common text editors
+- name: Install basic packages
   become: true
   ansible.builtin.apt:
     name:
@@ -7,6 +7,7 @@
     - vim
     - nano
     - evince
+    - tree
 
 - name: Add basic .vimrc
   become: true

--- a/playbook-build-dev.yml
+++ b/playbook-build-dev.yml
@@ -65,9 +65,9 @@
     become_user: "{{ vm_user }}"
     ansible.builtin.import_tasks: local/tasks/customise-bash.yml
 
-  - name: Install common text editors
-    tags: [editors]
-    ansible.builtin.import_tasks: local/tasks/editors.yml
+  - name: Install basic packages
+    tags: [basic]
+    ansible.builtin.import_tasks: local/tasks/basic-packages.yml
 
   - name: Install dev packages
     tags: [dev]


### PR DESCRIPTION
The `local/tasks/editors.yml` task had grown beyond text editors — it also installed `evince` and `graphicsmagick` — and `tree` is another general-purpose utility that does not fit under the "editors" label. Rename the file to `local/tasks/basic-packages.yml`, rename the apt task to "Install basic packages", and add `tree` to the package list. Update the corresponding entry in `playbook-build-dev.yml` to point at the new path and switch its tag from `editors` to `basic`.