### PR TITLE
🐛 Build: Expand root LV to fill the volume group on Vagrant

### DIFF
--- a/local/tasks/expand-rootfs.yml
+++ b/local/tasks/expand-rootfs.yml
@@ -1,0 +1,17 @@
+---
+# Bento Ubuntu boxes ship with a 64 GB physical disk but only ~30 GB allocated
+# to the root LV. Extend ubuntu-lv to use all free VG space, then grow the FS.
+
+- name: Extend root LV to fill VG
+  become: true
+  ansible.builtin.command: lvextend -l +100%FREE /dev/mapper/ubuntu--vg-ubuntu--lv
+  register: lvextend_result
+  changed_when: "'Size of logical volume' in lvextend_result.stdout"
+  failed_when:
+  - lvextend_result.rc != 0
+  - "'matches existing size' not in lvextend_result.stderr"
+
+- name: Resize ext4 filesystem on root LV
+  become: true
+  ansible.builtin.command: resize2fs /dev/mapper/ubuntu--vg-ubuntu--lv
+  when: lvextend_result.changed  # noqa: no-handler

--- a/playbook-build-dev.yml
+++ b/playbook-build-dev.yml
@@ -27,6 +27,11 @@
       cache_valid_time: 86400
       name: "linux-headers-{{ ansible_facts['kernel'] }}"
 
+  - name: Expand root filesystem to use full disk
+    tags: [init]
+    when: "inventory_hostname.startswith('vagrant')"
+    ansible.builtin.import_tasks: local/tasks/expand-rootfs.yml
+
   - name: Make local dist folder
     tags: [init]
     ansible.builtin.file:


### PR DESCRIPTION
The Bento `ubuntu-24.04` box ships with a ~64 GB physical disk partitioned via LVM, but only allocates ~30 GB of the volume group to the root logical volume `ubuntu-vg/ubuntu-lv` and leaves the remainder unallocated. Cloud-init's `growpart` only extends the partition (`sda3`), not the LVM layer above it, so `/` stays at 30 GB even though `vgs` reports another 30 GB free. Heavy code-env installs fill the root partition and crash provisioning with `No space left on device`.

Add a `local/tasks/expand-rootfs.yml` task that runs `lvextend -l +100%FREE` on the root LV and then `resize2fs` on the ext4 filesystem, and wire it into the base layer of `playbook-build-dev.yml` under the `init` tag, gated on `inventory_hostname.startswith('vagrant')` so the cloud/docker hosts (which do not have this LVM layout) skip the task. The `failed_when` tolerates the "matches existing size" message lvextend prints when the LV already fills the VG, so reruns are idempotent.