### PR TITLE
✨ `qe-school`: Add `metatomic` conda env with LAMMPS and GROMACS

### DIFF
--- a/local/tasks/conda-env-install.yml
+++ b/local/tasks/conda-env-install.yml
@@ -11,7 +11,9 @@
   become_user: "{{ vm_user }}"
   ansible.builtin.shell: >
     ~/.conda/bin/mamba {{ 'install' if conda_env_stat.stat.exists else 'create' }}
-    -n {{ conda_env }} -y {{ packages | join(' ') }}
+    -n {{ conda_env }} -y
+    {{ channels | default([]) | map('regex_replace', '^', '-c ') | join(' ') }}
+    {{ packages | join(' ') }}
   register: result
   changed_when: "'All requested packages already installed' not in result.stdout"
 

--- a/playbook-build-qe.yml
+++ b/playbook-build-qe.yml
@@ -12,6 +12,12 @@
     become_user: "{{ vm_user }}"
     ansible.builtin.import_tasks: qe-school/tasks/koopmans.yml
 
+  - name: Install metatomic conda environment
+    tags: [metatomic]
+    become: true
+    become_user: "{{ vm_user }}"
+    ansible.builtin.import_tasks: qe-school/tasks/metatomic-env.yml
+
   - name: Install code environments
     tags: [code-envs]
     ansible.builtin.include_tasks:

--- a/qe-school/tasks/metatomic-env.yml
+++ b/qe-school/tasks/metatomic-env.yml
@@ -1,0 +1,62 @@
+---
+
+- name: Install metatomic conda environment
+  ansible.builtin.include_tasks: local/tasks/conda-env-install.yml
+  vars:
+    conda_env: metatomic
+    channels:
+    - pytorch
+    - conda-forge
+    - metatensor
+    packages:
+    - python=3.12
+    - cpuonly
+    - lammps-metatomic=2025.09.10.mta3=cpu_*_mpi_openmpi_*
+    - gromacs-metatomic=2026.0.mta2=mpi_openmpi_h*
+    - jupyter=1.1.1
+    - chemiscope=1.0.2
+    - i-pi=3.2.0
+    - notebook
+    - ipykernel
+    - ipython
+    - numpy
+    - pandas
+    - matplotlib
+    - py3Dmol
+    - pip
+
+- name: Install metatomic pip packages
+  ansible.builtin.command:
+    cmd: >
+      ~/.conda/envs/metatomic/bin/pip install
+      --extra-index-url https://download.pytorch.org/whl/cpu
+      flashmd==0.2.8 metatrain==2026.2 upet==0.2.3
+    creates: "/home/{{ vm_user }}/.conda/envs/metatomic/lib/python3.12/site-packages/flashmd/__init__.py"
+
+- name: Register metatomic env as Jupyter kernel
+  ansible.builtin.command:
+    cmd: >
+      ~/.conda/envs/metatomic/bin/python -m ipykernel install --user
+      --name metatomic --display-name "Python (metatomic)"
+    creates: "/home/{{ vm_user }}/.local/share/jupyter/kernels/metatomic/kernel.json"
+
+- name: Smoke test metatomic Python imports
+  ansible.builtin.command:
+    cmd: >
+      ~/.conda/envs/metatomic/bin/python -c
+      "import numpy, pandas, matplotlib, py3Dmol, IPython,
+      torch, flashmd, metatrain, chemiscope, ipi"
+  changed_when: false
+
+- name: Smoke test LAMMPS
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      ~/.conda/envs/metatomic/bin/lmp -h | grep -q "Large-scale Atomic/Molecular Massively Parallel Simulator"
+    executable: /bin/bash
+  changed_when: false
+
+- name: Smoke test GROMACS
+  ansible.builtin.command:
+    cmd: ~/.conda/envs/metatomic/bin/gmx_mpi --version
+  changed_when: false


### PR DESCRIPTION
The MARVEL-ICTP QE School workshop runs ML-potential exercises against patched LAMMPS and GROMACS builds (`lammps-metatomic`, `gromacs-metatomic`) from the `metatensor` anaconda.org channel, alongside a Python stack with `i-pi`, `metatrain`, `flashmd`, `upet`, `chemiscope`, and Jupyter. Provision all of it as a single `metatomic` conda env in `qe-school/tasks/metatomic-env.yml`.

Extend `local/tasks/conda-env-install.yml` with an optional `channels:` var that emits `-c <channel>` flags before the package list, so the new env can request `pytorch`, `conda-forge`, and `metatensor`. Register the env as a Jupyter kernel (`Python (metatomic)`) and add smoke tests that import the Python stack and run `lmp -h` and `gmx_mpi --version`, so CI catches missing packages or broken binaries.