### PR TITLE
🐛 Bash: Set `OMP_NUM_THREADS=1` and pin OpenMPI to loopback

### DIFF
--- a/local/tasks/customise-bash.yml
+++ b/local/tasks/customise-bash.yml
@@ -39,3 +39,16 @@
     path: ~/.sudo_as_admin_successful
     state: touch
     mode: "0644"
+
+- name: Set default environment variables
+  ansible.builtin.blockinfile:
+    path: "${HOME}/.bashrc"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK (env vars)"
+    block: |
+      # OpenMP threading on top of MPI degrades performance for codes like QE,
+      # so pin to a single thread by default — users can override per shell.
+      export OMP_NUM_THREADS=1
+      # Restrict OpenMPI's TCP BTL to the loopback interface, otherwise
+      # `mpirun ... < input > output` fails on multi-NIC VMs with
+      # "Unable to find reachable pairing between local and remote interfaces".
+      export OMPI_MCA_btl_tcp_if_include=lo


### PR DESCRIPTION
Two small `.bashrc` exports that come up regularly when running MPI codes on the VM:

- `OMP_NUM_THREADS=1`: OpenMP threading layered on top of MPI degrades performance for codes like Quantum ESPRESSO. Default to one thread so users do not silently pay this cost; they can override per shell.
- `OMPI_MCA_btl_tcp_if_include=lo`: without this, `mpirun ... < input > output` on multi-NIC VMs fails with "Unable to find reachable pairing between local and remote interfaces". Restrict OpenMPI's TCP BTL to the loopback interface, which is all the VM ever needs.

Add the exports as a new ansible-managed block in
`local/tasks/customise-bash.yml` so they land in `~/.bashrc` for every variant (full, dev, qe-school) — the behaviour is not workshop-specific even though it surfaced during QE School testing.