### PR TITLE
✨ `qe-school`: Add `yambopy` and its deps to the yambo env

### DIFF
--- a/playbook-build-qe.yml
+++ b/playbook-build-qe.yml
@@ -38,9 +38,12 @@
     - name: wannier90
       pkgs: [wannier90=3.1.0]
       bin_patterns: ["wannier90.*", "w90*", "postw90.*"]
-    - name: yambo
-      pkgs: [yambo=5.3.0, libxc=6.2.2, openmpi=4.1.6]
-      bin_patterns: ["yambo*", "ypp*", a2y, c2y, p2y]
     when: item.arch is not defined or ansible_facts['architecture'] in item.arch
     loop_control:
       label: "{{ item.name }}"
+
+  - name: Install yambo conda environment
+    tags: [yambo-env]
+    become: true
+    become_user: "{{ vm_user }}"
+    ansible.builtin.import_tasks: qe-school/tasks/yambo-env.yml

--- a/qe-school/tasks/yambo-env.yml
+++ b/qe-school/tasks/yambo-env.yml
@@ -1,0 +1,40 @@
+---
+
+- name: Install yambo conda environment
+  ansible.builtin.include_tasks: local/tasks/conda-env-install.yml
+  vars:
+    conda_env: yambo
+    packages:
+    - yambo=5.3.0
+    - libxc=6.2.2
+    - openmpi=4.1.6
+    - python=3.13
+    - numpy
+    - scipy
+    - matplotlib
+    - netCDF4
+    - h5py
+    - pyyaml
+    - lxml
+    - monty
+    - scikit-learn
+    - tqdm
+    - spglib
+    - numba
+    - pykdtree
+    - pip
+
+- name: Install yambopy via pip
+  ansible.builtin.command:
+    cmd: ~/.conda/envs/yambo/bin/pip install yambopy
+    creates: "/home/{{ vm_user }}/.conda/envs/yambo/lib/python3.13/site-packages/yambopy/__init__.py"
+
+- name: Smoke test yambo binary
+  ansible.builtin.command:
+    cmd: ~/.conda/envs/yambo/bin/yambo -h
+  changed_when: false
+
+- name: Smoke test yambopy import
+  ansible.builtin.command:
+    cmd: ~/.conda/envs/yambo/bin/python -c "import yambopy"
+  changed_when: false


### PR DESCRIPTION
The QE School workshop runs Yambo exercises through `yambopy`, which is not on conda-forge and needs a specific set of conda packages installed alongside it (`numpy`, `scipy`, `matplotlib`, `netCDF4`, `h5py`, `pyyaml`, `lxml`, `monty`, `scikit-learn`, `tqdm`, `spglib`, `numba`, `pykdtree`) before the final `pip install yambopy` step. The previous yambo entry lived in the generic code-envs loop in `playbook-build-qe.yml`, which only supports a flat conda package list — no follow-up pip step and no env-specific smoke tests.

Pull yambo out of the loop into its own `qe-school/tasks/yambo-env.yml`, the same shape as `metatomic-env.yml`: conda env install via `conda-env-install.yml`, then a `pip install yambopy` step guarded by `creates:` on the installed `__init__.py`, then two smoke tests (`yambo -h` and `python -c "import yambopy"`) so CI catches missing packages or broken binaries. Pin `python=3.13` per the upstream recipe, even though yambo itself has no python dep — this matches what was requested by the workshop tutors.