### PR TITLE
👌 `qe-school`: Harmonise Python and OpenMPI pins across envs

### DIFF
--- a/qe-school/tasks/metatomic.yml
+++ b/qe-school/tasks/metatomic.yml
@@ -9,7 +9,7 @@
     - conda-forge
     - metatensor
     packages:
-    - python=3.12
+    - python=3.13
     - cpuonly
     - libtorch=*=cpu_*
     - libopenblas
@@ -31,7 +31,7 @@
       ~/.conda/envs/metatomic/bin/pip install
       --extra-index-url https://download.pytorch.org/whl/cpu
       flashmd==0.2.8 metatrain==2026.2 upet==0.2.3
-    creates: "/home/{{ vm_user }}/.conda/envs/metatomic/lib/python3.12/site-packages/flashmd/__init__.py"
+    creates: "/home/{{ vm_user }}/.conda/envs/metatomic/lib/python3.13/site-packages/flashmd/__init__.py"
 
 - name: Register metatomic env as Jupyter kernel
   ansible.builtin.command:

--- a/qe-school/tasks/qe.yml
+++ b/qe-school/tasks/qe.yml
@@ -6,7 +6,8 @@
     conda_env: qe
     packages:
     - qe=7.5
-    - openmpi=5.0.8
+    - openmpi=4.1.6
+    - python=3.13
     - ase
     - numpy
     - matplotlib


### PR DESCRIPTION
The workshop envs had drifted to two Python minors (`python=3.12` in `metatomic`, `python=3.13` in `wannier` and `yambo`, unpinned in `qe`) and two OpenMPI majors (`openmpi=5.0.8` in `qe`, `openmpi=4.1.6` in `yambo`). Conda only shares packages between envs when the version *and* build string match — different Python minors mean every compiled wheel (numpy, scipy, matplotlib, ...) lands twice in `~/.conda/pkgs/`, and different OpenMPI majors duplicate the MPI-linked dependency tree on top.

Bump `metatomic` from `python=3.12` to `python=3.13`, pin `python=3.13` explicitly in `qe`, and switch `qe` from `openmpi=5.0.8` to `openmpi=4.1.6` so the entire workshop image converges on one Python minor and one OpenMPI major.