### PR TITLE
🔄 `qe-school`: Launch JupyterLab from a terminal desktop shortcut

### DIFF
--- a/qe-school/tasks/jupyter.yml
+++ b/qe-school/tasks/jupyter.yml
@@ -6,6 +6,7 @@
     conda_env: jupyter
     packages:
     - jupyterlab=4.5.7
+    - chemiscope=1.0.3
     bin_patterns: ["jupyter", "jupyter-lab"]
 
 - name: "Get home for user: {{ vm_user }}"
@@ -25,36 +26,10 @@
     mode: "0755"
     content: |
       #!/bin/bash
-      {{ vm_user_home.path }}/.conda/bin/conda run --no-capture-output -n jupyter jupyter-lab \
-        -y \
-        --notebook-dir={{ vm_user_home.path }} \
+      exec {{ vm_user_home.path }}/.conda/envs/jupyter/bin/jupyter-lab \
+        -y --notebook-dir={{ vm_user_home.path }} \
         --ip=localhost --port=8891 \
-        --ServerApp.token=7c8a1215d6768f78e8300804741bd3883d7b1510159b755e \
-        --no-browser
-
-- name: Add Jupyter lab as systemd service
-  become: true
-  become_user: "{{ root_user }}"
-  ansible.builtin.template:
-    src: files/jupyter.service
-    dest: /etc/systemd/system
-    owner: root
-    group: root
-    mode: "0644"
-  vars:
-    jupyter_user: "{{ vm_user }}"
-    jupyter_script: "{{ vm_user_home.path }}/.jupyter-lab.sh"
-
-- name: Start Jupyter lab systemd service
-  tags: [ci_skip]
-  become: true
-  become_user: "{{ root_user }}"
-  ansible.builtin.systemd:
-    name: jupyter
-    enabled: true
-    masked: false
-    daemon-reload: true
-    state: started
+        --ServerApp.token=7c8a1215d6768f78e8300804741bd3883d7b1510159b755e
 
 - name: Copy Jupyter logo
   become: true
@@ -75,7 +50,8 @@
       Encoding=UTF-8
       Name=JupyterLab
       Comment=Launch Jupyter Lab Server
-      Exec={{ vm_browser }} "http://localhost:8891/?token=7c8a1215d6768f78e8300804741bd3883d7b1510159b755e"
+      Exec={{ vm_user_home.path }}/.jupyter-lab.sh
+      Terminal=true
       Icon=/usr/share/icons/jupyter-logo.png
       Type=Application
 

--- a/qe-school/tasks/metatomic.yml
+++ b/qe-school/tasks/metatomic.yml
@@ -14,8 +14,7 @@
     - libtorch=*=cpu_*
     - libopenblas
     - lammps-metatomic=2025.09.10.mta3=cpu_*_mpi_openmpi_*
-    - gromacs-metatomic=2026.0.mta2=mpi_openmpi_h*
-    - chemiscope=1.0.2
+    - chemiscope=1.0.3
     - i-pi=3.2.0
     - ipykernel
     - ipython
@@ -54,9 +53,4 @@
       set -o pipefail
       ~/.conda/envs/metatomic/bin/lmp -h 2>&1 | grep "Large-scale Atomic/Molecular Massively Parallel Simulator"
     executable: /bin/bash
-  changed_when: false
-
-- name: Smoke test GROMACS
-  ansible.builtin.command:
-    cmd: ~/.conda/envs/metatomic/bin/gmx_mpi --version
   changed_when: false


### PR DESCRIPTION
The previous setup ran JupyterLab as a systemd service and pointed the desktop shortcut at the already-served URL. Widgets (specifically `chemiscope.show(...)` in the metatomic env) rendered partially and then threw `TypeError: Cannot read properties of null (reading 'remove')` in the browser — but only when the lab was launched via systemd. The same `conda run -n jupyter jupyter-lab` invocation from an interactive shell rendered widgets correctly.

Drop the systemd unit, the background launcher, and the `{{ vm_browser }} URL`-style desktop shortcut. Replace them with a one-line launcher (`exec ~/.conda/envs/jupyter/bin/jupyter-lab ...` on `localhost:8891` with the fixed token, no `--no-browser`) and a `.desktop` entry that sets `Terminal=true`, so double-clicking the icon opens the default terminal emulator, runs the launcher in the foreground, and lets jupyter-lab auto-open the browser. The terminal gives users a Ctrl+C handle to stop the server, the process inherits the full GUI session env, and chemiscope widgets render correctly.

Tradeoffs: no auto-start on boot, no auto-restart on crash, and the terminal window stays open for the lab's lifetime — all acceptable for a workshop image where participants explicitly launch the lab once per session.

To make sure the chemiscope widgets render correctly, we add chemiscope as a dependency of the jupyter environment. We also bump both versions to 1.0.3.

Since the tutors indicated they no longer needed gromacs, we removed the dependency.