### PR TITLE
🐛 `Bash`: Silence PMIx `munge` plugin warning

### DIFF
--- a/local/tasks/customise-bash.yml
+++ b/local/tasks/customise-bash.yml
@@ -52,3 +52,7 @@
       # `mpirun ... < input > output` fails on multi-NIC VMs with
       # "Unable to find reachable pairing between local and remote interfaces".
       export OMPI_MCA_btl_tcp_if_include=lo
+      # PMIx probes its `psec` security plugins at startup and warns when the
+      # `munge` plugin's libs are missing. Munge is for Slurm/cluster auth,
+      # irrelevant on a single-node VM — exclude it to silence the warning.
+      export PMIX_MCA_psec=^munge


### PR DESCRIPTION
Fixes #287 

Running any MPI job on the VM prints a noisy PMIx warning that the `munge` security component could not be loaded. PMIx probes its `psec` plugins at startup regardless of how the job is launched, and `munge` is only relevant for Slurm/cluster authentication — on a single-node VM it is dead weight, and the warning confuses users into thinking their MPI run failed.

Exclude the plugin by exporting `PMIX_MCA_psec=^munge` from the env-vars block in the bash customisation task, alongside the existing OpenMPI tweaks.