### PR TITLE
✨ `qe-school`: Add `cdd` + `update` and post-distribution playbook hook

### DIFF
--- a/custom/tasks/materials.yml
+++ b/custom/tasks/materials.yml
@@ -1,0 +1,167 @@
+---
+# Clone the school materials repo and install shell helpers (`cdd`, `update`)
+# so students can jump to a day's directory + activate its conda env, and pull
+# fresh upstream material without ever losing their local changes.
+#
+# `update` also replays an ansible playbook bundled in the materials repo at
+# `.ansible/playbook.yml`, so tutors can ship system-level fixes (new conda
+# envs, apt packages, file tweaks) after the VM has been distributed.
+
+- name: Clone ictp-marvel-college-2026 to ~/materials
+  ansible.builtin.git:
+    repo: https://github.com/mbercx/ictp-marvel-college-2026.git  # TODO: switch back to marvel-nccr/ before distribution
+    dest: "/home/{{ vm_user }}/materials"
+    version: main
+    accept_hostkey: true
+    update: false  # re-provisions are no-op; refresh via `update` from inside the VM
+
+- name: Install ansible conda env (used by `update` to replay the bundled playbook)
+  ansible.builtin.include_tasks: local/tasks/conda-env-install.yml
+  vars:
+    conda_env: ansible
+    packages:
+    - python=3.13
+    - ansible-core
+    bin_patterns: []
+
+- name: Install community.general collection (for the `unixy` stdout callback)
+  ansible.builtin.command:
+    cmd: ~/.conda/envs/ansible/bin/ansible-galaxy collection install community.general
+    creates: ~/.ansible/collections/ansible_collections/community/general
+
+- name: Set default git identity (so `update`'s wip commit works out of the box)
+  community.general.git_config:
+    scope: global
+    name: "{{ item.key }}"
+    value: "{{ item.value }}"
+  loop:
+  - { key: user.name, value: "{{ vm_user }}" }
+  - { key: user.email, value: "{{ vm_user }}@qmobile.local" }
+
+- name: Install `cdd` and `update` shell helpers
+  ansible.builtin.blockinfile:
+    path: "/home/{{ vm_user }}/.bashrc"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK (materials helpers)"
+    block: |
+      # day-NN → conda env mapping for the ICTP MARVEL College
+      declare -A _qm_day_env=(
+        [01]=qe [02]=qe [03]=yambo [04]=wannier [05]=koopmans
+        [06]=metatomic [07]=metatomic [08]=metatomic [09]=metatomic [10]=metatomic
+      )
+
+      # `cdd N` — cd into ~/materials/day-NN-* and activate the matching env.
+      cdd() {
+        if [[ -z "$1" ]]; then
+          echo "usage: cdd <day-number>" >&2
+          return 1
+        fi
+
+        local num
+        printf -v num '%02d' "$1"
+
+        local dir
+        dir=$(ls -d "$HOME/materials/day-${num}"*/ 2>/dev/null | head -n1)
+
+        if [[ -z "$dir" ]]; then
+          echo "❌ No day-${num}* directory under ~/materials" >&2
+          return 1
+        fi
+        cd "$dir" || return 1
+
+        local env="${_qm_day_env[$num]}"
+        if [[ -n "$env" ]]; then
+          workon "$env"
+        fi
+      }
+
+      # `update` — pull fresh material from upstream and, if the bundled
+      # ansible playbook changed, replay it to apply system updates.
+      update() {
+        local lock=$HOME/.qm-update.lock
+        exec 9>"$lock"
+        if ! flock -n 9; then
+          echo "❌ Another update is already running!" >&2
+          return 1
+        fi
+
+        local _qm_origcwd=$PWD
+        cd "$HOME/materials" || return 1
+
+        if [[ -d .git/rebase-merge || -d .git/rebase-apply ]]; then
+          echo "🔄 Cleaning up stale rebase state from a previous interrupted update..."
+          git rebase --abort 2>/dev/null
+        fi
+
+        if ! git fetch origin; then
+          echo "❌ Update failed to connect to GitHub. Are you offline?" >&2
+          cd "$_qm_origcwd" 2>/dev/null
+          return 1
+        fi
+
+        git add -A
+        git commit -m "qm-update wip $(date -Iseconds)" --allow-empty --quiet
+
+        local _qm_rebase_ok=1
+
+        if ! git rebase -X theirs origin/main; then
+          _qm_rebase_ok=0
+          while [[ -d .git/rebase-merge || -d .git/rebase-apply ]]; do
+            local _qm_ud _qm_du
+            _qm_ud=$(git status --porcelain | awk '/^UD /{print $2}')
+            _qm_du=$(git status --porcelain | awk '/^DU /{print $2}')
+
+            if [[ -z "$_qm_ud" && -z "$_qm_du" ]]; then
+              break  # other conflict type we can't auto-resolve
+            fi
+
+            [[ -n "$_qm_ud" ]] && echo "$_qm_ud" | xargs git rm --quiet
+            [[ -n "$_qm_du" ]] && echo "$_qm_du" | xargs git add
+
+            git rebase --continue --quiet || true  # may pause on next conflict
+          done
+          # Rebase is truly done only when no rebase state dir remains.
+          [[ ! -d .git/rebase-merge && ! -d .git/rebase-apply ]] && _qm_rebase_ok=1
+        fi
+        if [[ $_qm_rebase_ok -eq 0 ]]; then
+          git rebase --abort 2>/dev/null
+          git reset --soft HEAD~1 --quiet
+          git reset --quiet
+          echo "❌ Update failed to rebase! Skipped but your work is intact." >&2
+          cd "$_qm_origcwd" 2>/dev/null
+          return 1
+        fi
+        git reset --soft HEAD~1 --quiet
+        git reset --quiet  # unstage so the working tree looks unchanged
+
+        # Replay bundled playbook if it changed since the last successful run.
+        local playbook=$HOME/materials/.ansible/playbook.yml
+        if [[ -f "$playbook" ]]; then
+          local current_sha
+          current_sha=$(git rev-parse HEAD:.ansible 2>/dev/null) || current_sha=""
+          local applied_sha=""
+
+          [[ -f $HOME/.qm-update-state ]] && applied_sha=$(<"$HOME/.qm-update-state")
+
+          if [[ -n "$current_sha" && "$current_sha" != "$applied_sha" ]]; then
+            echo "🚀 Applying system updates (this may take a moment)..."
+            local _qm_ansible_log
+            _qm_ansible_log=$(mktemp)
+
+            if (cd "$HOME/materials/.ansible" && \
+                ~/.conda/envs/ansible/bin/ansible-playbook \
+                -i "localhost," -c local playbook.yml) >"$_qm_ansible_log" 2>&1; then
+              echo "✅ System updates applied"
+              echo "$current_sha" > "$HOME/.qm-update-state"
+              rm -f "$_qm_ansible_log"
+            else
+              cat "$_qm_ansible_log"
+              rm -f "$_qm_ansible_log"
+              echo "❌ Playbook failed! Please retry on next update." >&2
+              cd "$_qm_origcwd" 2>/dev/null
+              return 1
+            fi
+          fi
+        fi
+        cd "$_qm_origcwd" 2>/dev/null
+        echo "✅ Success! All updates complete."
+      }

--- a/playbook-build-custom.yml
+++ b/playbook-build-custom.yml
@@ -60,3 +60,9 @@
           COMPREPLY=( $(compgen -W "koopmans metatomic qe sscha wannier yambo" -- "${COMP_WORDS[COMP_CWORD]}") )
         }
         complete -F _workon workon
+
+  - name: Clone materials repo and install cdd/update helpers
+    tags: [materials]
+    become: true
+    become_user: "{{ vm_user }}"
+    ansible.builtin.import_tasks: custom/tasks/materials.yml


### PR DESCRIPTION
Workshop participants need two things the base QE School image did not provide. First, a quick way to jump into a specific day's materials directory and activate the matching conda env without remembering each tutorial's naming scheme. Second, a way for organisers to ship system-level fixes (new conda packages, file tweaks) AFTER the image has been distributed without making participants re-download a multi-GB OVA mid-school.

Add `custom/tasks/materials.yml`, imported from `playbook-build-custom.yml`, which does the following at build time:

- Clones `ictp-marvel-college-2026` to `~/materials` (currently from `mbercx/`; switch back to `marvel-nccr/` before distribution — TODO inline).
- Installs an `ansible` conda env (`ansible-core` + `community.general` for the `unixy` stdout callback) used to replay the bundled playbook in-place.
- Sets a default git identity so the wip commit `update` makes can be created without a "please tell me who you are" prompt.
- Drops two bash functions into `~/.bashrc`: `cdd N` cds into `~/materials/day-NN*/` and runs `workon <env>` from a built-in day-to-env table; `update` pulls fresh material and replays the playbook.

`update`'s safety contract is "student work is never lost". It runs under an `flock` so concurrent invocations refuse to race; auto-aborts stale rebase state from a prior Ctrl-C; snapshots the whole working tree as a wip commit; rebases onto `origin/main` with `-X theirs` so student edits silently win on content conflicts; and for modify/delete conflicts (which `-X` does not cover) loops through `UD`/`DU` paths honouring the student's intent before calling `git rebase --continue`. Soft-reset undoes the wip commit and the working tree is restored. If the rebase still cannot complete, everything is rolled back and the student is told the update was skipped.

After a successful rebase, `update` compares the tree-SHA of `.ansible/` against `~/.qm-update-state`. If it changed, the bundled playbook runs from inside `~/materials/.ansible/` (so it picks up its own `ansible.cfg`), with stdout captured to a tempfile that is only shown on failure. The SHA marker is written ONLY on full success, so a Ctrl-C or playbook failure leaves the marker untouched and the next `update` retries.